### PR TITLE
Revert "update url"

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "0g-storage-contracts"]
 	path = 0g-storage-contracts
-	url = https://github.com/0glabs/0g-storage-contracts.git
+	url = git@github.com:0glabs/0g-storage-contracts.git
 [submodule "0g-storage-client"]
 	path = 0g-storage-client
-	url = https://github.com/0glabs/0g-storage-client.git
+	url = git@github.com:0glabs/0g-storage-client.git


### PR DESCRIPTION
This PR incorrectly points to the `main` branch of submodule `0g-storage-contracts`, where the `compiled` branch is expected.

The corresponding submodule commit has been reverted. 

Reference: https://github.com/0glabs/0g-storage-contracts/pull/2

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/0glabs/0g-storage-node/28)
<!-- Reviewable:end -->
