### PR TITLE
Update config.toml, open rpc_listen_address_admin

### DIFF
--- a/run/config.toml
+++ b/run/config.toml
@@ -131,7 +131,7 @@ log_page_size = 999
 rpc_listen_address = "0.0.0.0:5678"
 
 # HTTP server address to bind for admin and debug RPC.
-# rpc_listen_address_admin = "127.0.0.1:5679"
+rpc_listen_address_admin = "0.0.0.0:5679"
 
 # Maximum data size of RPC request body (by default, 100MB).
 # max_request_body_size = 104857600


### PR DESCRIPTION
based on the latest config.toml set of storage-kv, the storage node's rpc_listen_address_admin needs to be opened

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/0glabs/0g-storage-node/89)
<!-- Reviewable:end -->
