### PR TITLE
Fix some issues in sync package

### DIFF
--- a/node/sync/src/auto_sync/mod.rs
+++ b/node/sync/src/auto_sync/mod.rs
@@ -1,7 +1,7 @@
 mod batcher;
 pub mod batcher_random;
 pub mod batcher_serial;
-mod sync_store;
+pub mod sync_store;
 mod tx_store;
 
 use std::time::Duration;

--- a/node/sync/src/auto_sync/sync_store.rs
+++ b/node/sync/src/auto_sync/sync_store.rs
@@ -68,7 +68,6 @@ impl SyncStore {
     }
 
     pub async fn set_max_tx_seq(&self, tx_seq: u64) -> Result<()> {
-        debug!(%tx_seq, "set_max_tx_seq");
         self.store
             .get_store()
             .set_config_encoded(&KEY_MAX_TX_SEQ, &tx_seq)

--- a/node/sync/src/controllers/mod.rs
+++ b/node/sync/src/controllers/mod.rs
@@ -1,6 +1,9 @@
 mod peers;
 mod serial;
 
+use std::collections::HashMap;
+
+use peers::PeerState;
 use serde::{Deserialize, Serialize};
 
 pub use serial::{FailureReason, SerialSyncController, SyncState, MAX_CHUNKS_TO_REQUEST};
@@ -42,7 +45,7 @@ impl FileSyncGoal {
 #[serde(rename_all = "camelCase")]
 pub struct FileSyncInfo {
     pub elapsed_secs: u64,
-    pub peers: usize,
+    pub peers: HashMap<PeerState, u64>,
     pub goal: FileSyncGoal,
     pub next_chunks: u64,
     pub state: String,

--- a/node/sync/src/controllers/peers.rs
+++ b/node/sync/src/controllers/peers.rs
@@ -10,6 +10,7 @@ use std::vec;
 use storage::config::ShardConfig;
 
 use crate::context::SyncNetworkContext;
+use crate::InstantWrapper;
 
 const PEER_CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
 const PEER_DISCONNECT_TIMEOUT: Duration = Duration::from_secs(5);
@@ -34,13 +35,13 @@ struct PeerInfo {
     pub shard_config: ShardConfig,
 
     /// Timestamp of the last state change.
-    pub since: Instant,
+    pub since: InstantWrapper,
 }
 
 impl PeerInfo {
     fn update_state(&mut self, new_state: PeerState) {
         self.state = new_state;
-        self.since = Instant::now();
+        self.since = Instant::now().into();
     }
 }
 
@@ -82,7 +83,7 @@ impl SyncPeers {
                 addr,
                 state: PeerState::Found,
                 shard_config,
-                since: Instant::now(),
+                since: Instant::now().into(),
             },
         );
 
@@ -364,7 +365,7 @@ mod tests {
         sync_peers.add_new_peer(peer_id_connecting, addr.clone());
         sync_peers.update_state_force(&peer_id_connecting, PeerState::Connecting);
         sync_peers.peers.get_mut(&peer_id_connecting).unwrap().since =
-            Instant::now() - PEER_CONNECT_TIMEOUT;
+            (Instant::now() - PEER_CONNECT_TIMEOUT).into();
 
         let peer_id_disconnecting = identity::Keypair::generate_ed25519().public().to_peer_id();
         sync_peers.add_new_peer(peer_id_disconnecting, addr.clone());
@@ -373,7 +374,7 @@ mod tests {
             .peers
             .get_mut(&peer_id_disconnecting)
             .unwrap()
-            .since = Instant::now() - PEER_DISCONNECT_TIMEOUT;
+            .since = (Instant::now() - PEER_DISCONNECT_TIMEOUT).into();
 
         let peer_id_disconnected = identity::Keypair::generate_ed25519().public().to_peer_id();
         sync_peers.add_new_peer(peer_id_disconnected, addr);

--- a/node/sync/src/controllers/serial.rs
+++ b/node/sync/src/controllers/serial.rs
@@ -124,7 +124,7 @@ impl SerialSyncController {
     pub fn get_sync_info(&self) -> FileSyncInfo {
         FileSyncInfo {
             elapsed_secs: self.since.elapsed().as_secs(),
-            peers: self.peers.count(&[PeerState::Connected]),
+            peers: self.peers.states(),
             goal: self.goal,
             next_chunks: self.next_chunk,
             state: format!("{:?}", self.state),

--- a/node/sync/src/lib.rs
+++ b/node/sync/src/lib.rs
@@ -31,7 +31,7 @@ impl Default for Config {
     fn default() -> Self {
         Self {
             auto_sync_enabled: false,
-            max_sync_files: 8,
+            max_sync_files: 16,
             sync_file_by_rpc_enabled: true,
             sync_file_on_announcement_enabled: false,
 

--- a/node/sync/src/lib.rs
+++ b/node/sync/src/lib.rs
@@ -11,7 +11,10 @@ pub use controllers::FileSyncInfo;
 use duration_str::deserialize_duration;
 use serde::Deserialize;
 pub use service::{SyncMessage, SyncReceiver, SyncRequest, SyncResponse, SyncSender, SyncService};
-use std::time::Duration;
+use std::{
+    fmt::Debug,
+    time::{Duration, Instant},
+};
 
 #[derive(Clone, Copy, Debug, Deserialize)]
 #[serde(default)]
@@ -38,5 +41,26 @@ impl Default for Config {
             max_sequential_workers: 8,
             find_peer_timeout: Duration::from_secs(10),
         }
+    }
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub struct InstantWrapper(Instant);
+
+impl Debug for InstantWrapper {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "\"{} seconds ago\"", self.0.elapsed().as_secs())
+    }
+}
+
+impl From<Instant> for InstantWrapper {
+    fn from(value: Instant) -> Self {
+        Self(value)
+    }
+}
+
+impl InstantWrapper {
+    pub fn elapsed(&self) -> Duration {
+        self.0.elapsed()
     }
 }

--- a/node/sync/src/service.rs
+++ b/node/sync/src/service.rs
@@ -1,5 +1,6 @@
 use crate::auto_sync::batcher_random::RandomBatcher;
 use crate::auto_sync::batcher_serial::SerialBatcher;
+use crate::auto_sync::sync_store::SyncStore;
 use crate::context::SyncNetworkContext;
 use crate::controllers::{
     FailureReason, FileSyncGoal, FileSyncInfo, SerialSyncController, SyncState,
@@ -164,14 +165,17 @@ impl SyncService {
         // init auto sync
         let file_announcement_send = if config.auto_sync_enabled {
             let (send, recv) = unbounded_channel();
+            let sync_store = Arc::new(SyncStore::new(store.clone()));
 
             // sync in sequence
             let serial_batcher =
-                SerialBatcher::new(config, store.clone(), sync_send.clone()).await?;
+                SerialBatcher::new(config, store.clone(), sync_send.clone(), sync_store.clone())
+                    .await?;
             executor.spawn(serial_batcher.start(recv, event_recv), "auto_sync_serial");
 
             // sync randomly
-            let random_batcher = RandomBatcher::new(config, store.clone(), sync_send.clone());
+            let random_batcher =
+                RandomBatcher::new(config, store.clone(), sync_send.clone(), sync_store);
             executor.spawn(random_batcher.start(), "auto_sync_random");
 
             Some(send)

--- a/run/config.toml
+++ b/run/config.toml
@@ -226,7 +226,7 @@ miner_key = ""
 # auto_sync_enabled = false
 
 #  Maximum number of files in sync from other peers simultaneously.
-# max_sync_files = 8
+# max_sync_files = 16
 
 # Timeout to terminate a file sync when automatically sync from other peers.
 # If timeout, terminated file sync will be triggered later.


### PR DESCRIPTION
1. Change default concurrent sync threads to avoid random sync rate limited.
2. Enhance log level in sync store.
3. Add `RwLock` in sync store to avoid concurrency issue.
4. Enhance `serial` sync log.
5. Wrap `Instant` for debug purpose.
6. Randomly pick a peer to sync chunks.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/0glabs/0g-storage-node/111)
<!-- Reviewable:end -->
