### PR TITLE
Terminate file sync if failed

### DIFF
--- a/node/rpc/src/admin/api.rs
+++ b/node/rpc/src/admin/api.rs
@@ -22,7 +22,7 @@ pub trait Rpc {
 
     /// Terminate file or chunks sync for specified tx_seq.
     #[method(name = "terminateSync")]
-    async fn terminate_sync(&self, tx_seq: u64) -> RpcResult<()>;
+    async fn terminate_sync(&self, tx_seq: u64) -> RpcResult<bool>;
 
     #[method(name = "getSyncStatus")]
     async fn get_sync_status(&self, tx_seq: u64) -> RpcResult<String>;

--- a/node/rpc/src/admin/impl.rs
+++ b/node/rpc/src/admin/impl.rs
@@ -78,7 +78,7 @@ impl RpcServer for RpcServerImpl {
     }
 
     #[tracing::instrument(skip(self), err)]
-    async fn terminate_sync(&self, tx_seq: u64) -> RpcResult<()> {
+    async fn terminate_sync(&self, tx_seq: u64) -> RpcResult<bool> {
         info!("admin_terminateSync({tx_seq})");
 
         let response = self
@@ -90,7 +90,7 @@ impl RpcServer for RpcServerImpl {
             .await?;
 
         match response {
-            SyncResponse::TerminateFileSync { .. } => Ok(()),
+            SyncResponse::TerminateFileSync { count } => Ok(count > 0),
             _ => Err(error::internal_error("unexpected response type")),
         }
     }

--- a/node/sync/src/auto_sync/batcher.rs
+++ b/node/sync/src/auto_sync/batcher.rs
@@ -86,10 +86,7 @@ impl Batcher {
             // File may be finalized during file sync, e.g. user uploaded file via RPC.
             // In this case, just terminate the file sync.
             let num_terminated = self.terminate_file_sync(tx_seq, false).await;
-            if num_terminated > 0 {
-                info!(%tx_seq, %num_terminated, "Terminate file sync due to file already finalized in db");
-            }
-
+            info!(%tx_seq, %num_terminated, "Terminate file sync due to file already finalized in db");
             return Ok(Some(SyncResult::Completed));
         }
 

--- a/node/sync/src/auto_sync/batcher.rs
+++ b/node/sync/src/auto_sync/batcher.rs
@@ -121,7 +121,10 @@ impl Batcher {
 
             // file sync failed
             Some(SyncState::Failed { reason }) => {
-                debug!(?reason, "Failed to sync file and terminate the failed file sync");
+                debug!(
+                    ?reason,
+                    "Failed to sync file and terminate the failed file sync"
+                );
                 self.terminate_file_sync(tx_seq, false).await;
                 Ok(Some(SyncResult::Failed))
             }

--- a/node/sync/src/auto_sync/batcher_serial.rs
+++ b/node/sync/src/auto_sync/batcher_serial.rs
@@ -251,8 +251,6 @@ impl SerialBatcher {
             self.next_tx_seq_in_db += 1;
         }
 
-
-
         if self.next_tx_seq_in_db > origin {
             info!(%origin, %self.next_tx_seq_in_db, "Move forward in db");
         }


### PR DESCRIPTION
Fix some auto sync issues:
1. Terminate file sync if failed. Otherwise, it will never be removed in memory automatically.
2. If file already finalized in db, then terminate the file sync immediately.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/0glabs/0g-storage-node/121)
<!-- Reviewable:end -->
