### PR TITLE
Change to a real version of Package

### DIFF
--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zgs_node"
-version = "0.3.0"
+version = "0.3.4"
 edition = "2021"
 
 [dependencies]


### PR DESCRIPTION
zgs_node from 0.3.0 to 0.3.4.

Please always update this value for the next release. It really hard to check the build version.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/0glabs/0g-storage-node/135)
<!-- Reviewable:end -->
