### PR TITLE
change the Pora result from debug to info

### DIFF
--- a/node/miner/src/mine.rs
+++ b/node/miner/src/mine.rs
@@ -210,7 +210,7 @@ impl PoraService {
                     let timer = time::Instant::now();
 
                     if let Some(answer) = miner.batch_iteration(nonce, self.iter_batch).await {
-                        debug!("Hit Pora answer {:?}", answer);
+                        info!("Hit Pora answer {:?}", answer);
                         if self.mine_answer_sender.send(answer).is_err() {
                             warn!("Mine submitter channel closed");
                         }


### PR DESCRIPTION
pora info is important for storage mining, better to promote the logging level to info

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/0glabs/0g-storage-node/192)
<!-- Reviewable:end -->
