### PR TITLE
test: use fixed 0g binary

### DIFF
--- a/tests/config/0gchain-init-genesis.sh
+++ b/tests/config/0gchain-init-genesis.sh
@@ -28,7 +28,7 @@ for ((i=0; i<$NUM_NODES; i++)) do
 	TMP_GENESIS=$ROOT_DIR/node$i/config/tmp_genesis.json
 
 	# Replace stake with neuron
-	$SED_I 's/stake/ua0gi/g' "$GENESIS"
+	$SED_I 's/"stake"/"ua0gi"/g' "$GENESIS"
 
 	# Replace the default evm denom of aphoton with neuron
 	$SED_I 's/aphoton/neuron/g' "$GENESIS"

--- a/tests/utility/build_binary.py
+++ b/tests/utility/build_binary.py
@@ -16,7 +16,6 @@ BSC_BINARY = "geth.exe" if is_windows_platform() else "geth"
 ZG_BINARY = "0gchaind.exe" if is_windows_platform() else "0gchaind"
 CLIENT_BINARY = "0g-storage-client.exe" if is_windows_platform() else "0g-storage-client"
 
-ZG_GIT_REV = "7bc25a060fab9c17bc9942b6747cd07a668d3042" # v0.1.0
 CLI_GIT_REV = "98d74b7e7e6084fc986cb43ce2c66692dac094a6"
 
 @unique
@@ -76,7 +75,6 @@ def build_zg(dir: str) -> BuildBinaryResult:
         dir=dir,
         binary_name=ZG_BINARY,
         github_url="https://github.com/0glabs/0g-chain.git",
-        git_rev=ZG_GIT_REV,
         build_cmd="make install; cp $(go env GOPATH)/bin/0gchaind .",
         compiled_relative_path=[],
     )

--- a/tests/utility/build_binary.py
+++ b/tests/utility/build_binary.py
@@ -75,7 +75,7 @@ def build_zg(dir: str) -> BuildBinaryResult:
         dir=dir,
         binary_name=ZG_BINARY,
         github_url="https://github.com/0glabs/0g-chain.git",
-        build_cmd="make install; cp $(go env GOPATH)/bin/0gchaind .",
+        build_cmd="git fetch origin pull/74/head:pr-74; git checkout pr-74; make install; cp $(go env GOPATH)/bin/0gchaind .",
         compiled_relative_path=[],
     )
 


### PR DESCRIPTION
- use fixed 0g binary in integration test

`mine_with_market` test will fail randomly due to a precision bug in 0g chain. The bug will be fixed in https://github.com/0glabs/0g-chain/pull/74.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/0glabs/0g-storage-node/218)
<!-- Reviewable:end -->
