### PR TITLE
Start nodes sequentially in tests to fix some random failure.

### DIFF
--- a/tests/test_framework/test_framework.py
+++ b/tests/test_framework/test_framework.py
@@ -209,13 +209,11 @@ class TestFramework:
             if i > 0:
                 time.sleep(1)
             node.start()
+            node.wait_for_rpc_connection()
 
         self.log.info("Wait the zgs_node launch for %d seconds", self.launch_wait_seconds)
         time.sleep(self.launch_wait_seconds)
         
-        for node in self.nodes:
-            node.wait_for_rpc_connection()
-
     def add_arguments(self, parser: argparse.ArgumentParser):
         parser.add_argument(
             "--conflux-binary",


### PR DESCRIPTION
Currently we use the config `network_libp2p_nodes` to connect nodes in the tests. This will not be retried, so if an early node starts too slowly, other nodes may fail to connect to it.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/0glabs/0g-storage-node/243)
<!-- Reviewable:end -->
