### PR TITLE
increase db_max_num_sectors to be about 1000GB

### DIFF
--- a/run/config-testnet-standard.toml
+++ b/run/config-testnet-standard.toml
@@ -176,7 +176,7 @@ mine_contract_address = "0x1785c8683b3c527618eFfF78d876d9dCB4b70285"
 # If this limit is reached, the node will update its `shard_position`
 # and store only half data.
 #
-db_max_num_sectors = 1000000000
+db_max_num_sectors = 4000000000
 
 # The format is <shard_id>/<shard_number>, where the shard number is 2^n.
 # This only applies if there is no stored shard config in db.

--- a/run/config-testnet-turbo.toml
+++ b/run/config-testnet-turbo.toml
@@ -188,7 +188,7 @@ mine_contract_address = "0x6815F41019255e00D6F34aAB8397a6Af5b6D806f"
 # If this limit is reached, the node will update its `shard_position`
 # and store only half data.
 #
-db_max_num_sectors = 1000000000
+db_max_num_sectors = 4000000000
 
 # The format is <shard_id>/<shard_number>, where the shard number is 2^n.
 # This only applies if there is no stored shard config in db.


### PR DESCRIPTION
Increase default max number of sectors to 4x as before (~ 1000 GB).

User needs to adjust accordingly for more/less allowed storage capacity.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/0glabs/0g-storage-node/272)
<!-- Reviewable:end -->
