### PR TITLE
Fix grammatical typos in documentation 

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ For in-depth technical details about 0G Storage, please read our [Intro to 0G St
 
 - If you want to run a node, please refer to the [Running a Node](https://docs.0g.ai/run-a-node/storage-node) guide.
 - If you want to conduct local testing, please refer to [Onebox Testing](https://github.com/0glabs/0g-storage-node/blob/main/docs/onebox-test.md) guide.
-- If you want build a project using 0G storage, please refer to the [0G Storage SDK](https://docs.0g.ai/build-with-0g/storage-sdk) guide.
+- If you want to build a project using 0G storage, please refer to the [0G Storage SDK](https://docs.0g.ai/build-with-0g/storage-sdk) guide.
 
 ## Support and Additional Resources
 We want to do everything we can to help you be successful while working on your contribution and projects. Here you'll find various resources and communities that may help you complete a project or contribute to 0G. 

--- a/docs/onebox-test.md
+++ b/docs/onebox-test.md
@@ -19,7 +19,7 @@ The blockchain node binaries will be compiled or downloaded from github to `test
 
 ## Run Tests
 
-Changes to the `tests` folder and run following command to run all tests:
+Changes to the `tests` folder and run the following command to run all tests:
 
 ```
 python test_all.py


### PR DESCRIPTION
### Pull Request Description:

**Typo Fixes:**

1. **"want build"** → **"want to build"**
2. **"run following"** → **"run the following"**

These changes fix grammatical errors in the documentation, improving readability and adherence to standard English.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/0glabs/0g-storage-node/287)
<!-- Reviewable:end -->
