### PR TITLE
Fix node launch process in test framework

### DIFF
--- a/tests/test_framework/test_framework.py
+++ b/tests/test_framework/test_framework.py
@@ -215,10 +215,12 @@ class TestFramework:
             if i > 0:
                 time.sleep(1)
             node.start()
-            node.wait_for_rpc_connection()
 
         self.log.info("Wait the zgs_node launch for %d seconds", self.launch_wait_seconds)
         time.sleep(self.launch_wait_seconds)
+
+        for node in self.nodes:
+            node.wait_for_rpc_connection()
         
     def add_arguments(self, parser: argparse.ArgumentParser):
         parser.add_argument(


### PR DESCRIPTION
Attempts to connect ZGS nodes should occur only after the node launches have been completed.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/0glabs/0g-storage-node/305)
<!-- Reviewable:end -->
