### PR TITLE
docs: typo fix Update introduction.md

### DIFF
--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -5,7 +5,7 @@
 0G Storage is the storage layer for the ZeroGravity data availability (DA) system. The 0G Storage layer holds three important features:
 
 * Built-in - It is natively built into the ZeroGravity DA system for data storage and retrieval.
-* General purpose - It is designed to support atomic transactions, mutable kv stores as well as archive log systems to enable wide range of applications with various data types.
+* General purpose - It is designed to support atomic transactions, mutable kv stores as well as archive log systems to enable a wide range of applications with various data types.
 * Incentive - Instead of being just a decentralized database, 0G Storage introduces PoRA mining algorithm to incentivize storage network participants.
 
 ## Integration


### PR DESCRIPTION
Hi team,  

I noticed a small typo in the phrase "to enable wide range of applications" where the article "a" was missing. This could potentially cause slight confusion or appear less polished in formal contexts.  

I've updated it to "to enable a wide range of applications" for correctness and to ensure clarity across all usages.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/0glabs/0g-storage-node/306)
<!-- Reviewable:end -->
