### PR TITLE
Fix spelling errors

### DIFF
--- a/common/lighthouse_metrics/src/lib.rs
+++ b/common/lighthouse_metrics/src/lib.rs
@@ -7,7 +7,7 @@
 //! block processing time).
 //! - `IncCounter`: used to represent an ideally ever-growing, never-shrinking integer (e.g.,
 //! number of block processing requests).
-//! - `IntGauge`: used to represent an varying integer (e.g., number of attestations per block).
+//! - `IntGauge`: used to represent a varying integer (e.g., number of attestations per block).
 //!
 //! ## Important
 //!

--- a/node/src/client/environment.rs
+++ b/node/src/client/environment.rs
@@ -1,4 +1,4 @@
-//! This crate aims to provide a common set of tools that can be used to create a "environment" to
+//! This crate aims to provide a common set of tools that can be used to create an "environment" to
 //! run Zgs services. This allows for the unification of creating tokio runtimes, etc.
 //!
 //! The idea is that the main thread creates an `Environment`, which is then used to spawn a


### PR DESCRIPTION
- Fixed "an varying" to "a varying" in `lib.rs`.
- Changed "a environment" to "an environment" in `environment.rs`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/0glabs/0g-storage-node/314)
<!-- Reviewable:end -->
