### PR TITLE
docs: Fix imperative mood in documentation instructions Update onebox…

### DIFF
--- a/docs/onebox-test.md
+++ b/docs/onebox-test.md
@@ -5,7 +5,7 @@
 ## Prerequisites
 
 - Requires python version: 3.8, 3.9 or 3.10, higher version is not guaranteed (e.g. failed to install `pysha3`).
-- Installs dependencies under root folder: `pip3 install -r requirements.txt`
+- Install dependencies under root folder: `pip3 install -r requirements.txt`
 
 ## Install Blockchain Nodes
 
@@ -19,7 +19,7 @@ The blockchain node binaries will be compiled or downloaded from github to `test
 
 ## Run Tests
 
-Changes to the `tests` folder and run the following command to run all tests:
+Change to the `tests` folder and run the following command to run all tests:
 
 ```
 python test_all.py


### PR DESCRIPTION
### Description
A couple of small grammatical issues in the documentation where the imperative mood wasn't used correctly.
Fixed "Changes" to "Change" and "Installs" to "Install" to align with the command-style instructions.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/0glabs/0g-storage-node/316)
<!-- Reviewable:end -->
