### PR TITLE
fix: Fix path handling in script execution

### DIFF
--- a/scripts/check_abis.sh
+++ b/scripts/check_abis.sh
@@ -1,12 +1,11 @@
-
 set -e
 
 artifacts_path="$1"
 
 check_abis() {
     for contract_name in "$@"; do
-        diff $(./scripts/search_abi.sh "$artifacts_path" "$contract_name.json") "storage-contracts-abis/$contract_name.json"
+        diff "$(./scripts/search_abi.sh "$artifacts_path" "$contract_name.json")" "storage-contracts-abis/$contract_name.json"
     done
 }
-check_abis DummyMarket DummyReward Flow PoraMine PoraMineTest FixedPrice ChunkLinearReward FixedPriceFlow
 
+check_abis DummyMarket DummyReward Flow PoraMine PoraMineTest FixedPrice ChunkLinearReward FixedPriceFlow


### PR DESCRIPTION
I noticed that paths with spaces or special characters were causing issues in the script execution.
I've added quotes around `$(./scripts/search_abi.sh "$artifacts_path" "$contract_name.json")` to ensure proper handling.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/0glabs/0g-storage-node/318)
<!-- Reviewable:end -->
