### PR TITLE
docs: fix Linux dependency setup by adding Node.js instruction

### DIFF
--- a/docs/run.md
+++ b/docs/run.md
@@ -13,6 +13,7 @@ Install the dependencies Node.js, yarn, hardhat.
   ```shell
   # node >=12.18
   sudo apt install npm
+  sudo apt install nodejs
   sudo npm install --global yarn
   sudo npm install --global hardhat
   ```


### PR DESCRIPTION
I noticed that the instructions for setting up dependencies on Linux were missing a key step: the installation of Node.js itself. Previously, only npm was mentioned, but for proper setup, Node.js needs to be installed first.

I’ve updated the documentation to include `sudo apt install nodejs` right after mentioning npm, ensuring everything works smoothly.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/0glabs/0g-storage-node/326)
<!-- Reviewable:end -->
