### PR TITLE
docs: fix grammatical error in "Mining Reward" section

### DIFF
--- a/docs/incentive-mechanism/mining-reward.md
+++ b/docs/incentive-mechanism/mining-reward.md
@@ -1,6 +1,6 @@
 # Mining Reward
 
-0G Storage creates pricing segments every 8 GB of data chunks over the data flow. Each pricing segment is associated with an Endowment Pool and a Reward Pool. The Endowment Pool collects the storage endowments of all the data chunks belongs to this pricing segment and releases a fixed ratio of balance to the Reward Pool every second. The rate of reward release is set to 4% per year.
+0G Storage creates pricing segments every 8 GB of data chunks over the data flow. Each pricing segment is associated with an Endowment Pool and a Reward Pool. The Endowment Pool collects the storage endowments of all the data chunks belong to this pricing segment and releases a fixed ratio of balance to the Reward Pool every second. The rate of reward release is set to 4% per year.
 
 The mining reward is paid to miners for providing data service. Miners receive mining reward when submit the first legitimate PoRA for a mining epoch to 0G Storage contract.
 


### PR DESCRIPTION
I noticed a grammatical error in the "Mining Reward" section.
The word "belongs" should be replaced with "belong" to match the plural subject "data chunks."  

The corrected sentence now reads:  
"...all the data chunks belong to this pricing segment..."  

This change ensures proper subject-verb agreement.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/0glabs/0g-storage-node/327)
<!-- Reviewable:end -->
