### PR TITLE
Fix spelling errors and correct minor errors

### DIFF
--- a/node/network/src/config.rs
+++ b/node/network/src/config.rs
@@ -103,7 +103,7 @@ pub struct Config {
     /// Subscribe to all subnets for the duration of the runtime.
     pub subscribe_all_subnets: bool,
 
-    /// Import/aggregate all attestations recieved on subscribed subnets for the duration of the
+    /// Import/aggregate all attestations received on subscribed subnets for the duration of the
     /// runtime.
     pub import_all_attestations: bool,
 

--- a/version-meld/enr/src/keys/mod.rs
+++ b/version-meld/enr/src/keys/mod.rs
@@ -42,9 +42,9 @@ pub trait EnrKey: Send + Sync + Unpin + 'static {
     /// Returns the public key associated with current key pair.
     fn public(&self) -> Self::PublicKey;
 
-    /// Provides a method to decode a raw public key from an ENR `BTreeMap` to a useable public key.
+    /// Provides a method to decode a raw public key from an ENR `BTreeMap` to a usable public key.
     ///
-    /// This method allows a key type to decode the raw bytes in an ENR to a useable
+    /// This method allows a key type to decode the raw bytes in an ENR to a usable
     /// `EnrPublicKey`. It takes the ENR's `BTreeMap` and returns a public key.
     ///
     /// Note: This specifies the supported key schemes for an ENR.

--- a/version-meld/enr/src/lib.rs
+++ b/version-meld/enr/src/lib.rs
@@ -1195,7 +1195,7 @@ mod tests {
         assert_eq!(enr.tcp4(), Some(tcp));
         assert!(enr.verify());
 
-        // Compare the encoding as the key itself can be differnet
+        // Compare the encoding as the key itself can be different
         assert_eq!(enr.public_key().encode(), key.public().encode(),);
     }
 


### PR DESCRIPTION
- Corrected spelling in `config.rs`:  
  - `"recieved"` → `"received"`  
- Improved terminology in `mod.rs`:  
  - `"useable"` → `"usable"`  
- Fixed wording in `lib.rs`:  
  - `"differnet"` → `"different"`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/0glabs/0g-storage-node/337)
<!-- Reviewable:end -->
