### PR TITLE
Fixing bug with incorrect argument handling in copy_abis function

### DIFF
--- a/scripts/update_abis.sh
+++ b/scripts/update_abis.sh
@@ -50,7 +50,7 @@ copy_file() {
 
 copy_abis() {
     for contract_name in "$@"; do
-        copy_file $(./scripts/search_abi.sh "$path/artifacts" "$contract_name.json") "storage-contracts-abis/$contract_name.json"
+        copy_file "$(./scripts/search_abi.sh "$path/artifacts" "$contract_name.json")" "storage-contracts-abis/$contract_name.json"
     done
 }
 


### PR DESCRIPTION
I noticed an issue in the `copy_abis` function where the command `$(./scripts/search_abi.sh "$path/artifacts" "$contract_name.json")` was used without quotes. This could lead to problems if the returned path contains spaces or special characters. I've fixed this by wrapping the command substitution in double quotes, ensuring the path is handled correctly.

The updated line now looks like this:

```bash
copy_file "$(./scripts/search_abi.sh "$path/artifacts" "$contract_name.json")" "storage-contracts-abis/$contract_name.json"
``` 

This small change ensures the path is treated as a single argument, avoiding potential issues.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/0glabs/0g-storage-node/342)
<!-- Reviewable:end -->
