### PR TITLE
chore: Fixed error in variable name (entris to entries)

### DIFF
--- a/tests/cli_submission_test.py
+++ b/tests/cli_submission_test.py
@@ -65,11 +65,11 @@ class CliSubmissionTest(TestFramework):
         wait_until(lambda: client.zgs_get_file_info(root) is not None)
         wait_until(lambda: client.zgs_get_file_info(root)["finalized"])
 
-        num_of_entris = bytes_to_entries(size)
-        if num_of_entris > 1:
-            start_idx = random.randint(0, num_of_entris - 2)
+        num_of_entries = bytes_to_entries(size)
+        if num_of_entries > 1:
+            start_idx = random.randint(0, num_of_entries - 2)
             end_idx = min(
-                random.randint(start_idx + 1, num_of_entris - 1), start_idx + ENTRY_SIZE
+                random.randint(start_idx + 1, num_of_entries - 1), start_idx + ENTRY_SIZE
             )
 
             assert_equal(
@@ -94,9 +94,9 @@ class CliSubmissionTest(TestFramework):
 
             wait_until(lambda: self.nodes[i].zgs_get_file_info(root)["finalized"])
 
-            # start_idx = random.randint(0, num_of_entris - 1)
+            # start_idx = random.randint(0, num_of_entries - 1)
             # end_idx = min(
-            #     random.randint(start_idx + 1, num_of_entris), start_idx + ENTRY_SIZE
+            #     random.randint(start_idx + 1, num_of_entries), start_idx + ENTRY_SIZE
             # )
 
             assert_equal(


### PR DESCRIPTION
I noticed a typo in the code where the variable `entris` was being used. It should have been `entries`.

I’ve corrected this in all occurrences to ensure consistency and avoid any confusion.

The issue was particularly noticeable in the variable `num_of_entris`, which has now been updated to `num_of_entries`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/0glabs/0g-storage-node/345)
<!-- Reviewable:end -->
