### PR TITLE
fix: Replace deprecated `ONCE_INIT` with `Once::new()` for Rust compatibility 

### DIFF
--- a/common/merkle_light/benches/ringx/init.rs
+++ b/common/merkle_light/benches/ringx/init.rs
@@ -20,7 +20,7 @@ pub fn init_once() {
         extern "C" {
             fn GFp_cpuid_setup();
         }
-        static INIT: std::sync::Once = std::sync::ONCE_INIT;
+        static INIT: std::sync::Once = std::sync::Once::new();
         INIT.call_once(|| unsafe { GFp_cpuid_setup() });
     }
 }


### PR DESCRIPTION
This PR replaces the deprecated `std::sync::ONCE_INIT` with `std::sync::Once::new()` to ensure compatibility with modern Rust versions (1.38+). The previous usage of `ONCE_INIT` generated deprecation warnings and could potentially break in future Rust updates.

Before Fix (Error)
![Pasted Graphic 5](https://github.com/user-attachments/assets/203b71f0-f17b-4754-a2ba-cbfa5b070c65)

After Fix (Successful Build)
![image](https://github.com/user-attachments/assets/d69bbdff-6c2a-4a3c-b906-8d5239745e69)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/0glabs/0g-storage-node/350)
<!-- Reviewable:end -->
