### PR TITLE
 Fix Typos in Function Names 

### DIFF
--- a/node/file_location_cache/src/file_location_cache.rs
+++ b/node/file_location_cache/src/file_location_cache.rs
@@ -358,7 +358,7 @@ mod tests {
     }
 
     #[test]
-    fn test_annoucement_cache_peek_priority() {
+    fn test_announcement_cache_peek_priority() {
         let mut cache = AnnouncementCache::new(100, 3600);
         let now = timestamp_now();
 
@@ -382,7 +382,7 @@ mod tests {
     }
 
     #[test]
-    fn test_annoucement_cache_pop_len() {
+    fn test_announcement_cache_pop_len() {
         let mut cache = AnnouncementCache::new(100, 3600);
         let now = timestamp_now();
 
@@ -404,7 +404,7 @@ mod tests {
     }
 
     #[test]
-    fn test_annoucement_cache_garbage_collect() {
+    fn test_announcement_cache_garbage_collect() {
         let mut cache = AnnouncementCache::new(100, 3600);
         let now = timestamp_now();
 
@@ -422,7 +422,7 @@ mod tests {
     }
 
     #[test]
-    fn test_annoucement_cache_insert_gc() {
+    fn test_announcement_cache_insert_gc() {
         let mut cache = AnnouncementCache::new(100, 3600);
         let now = timestamp_now();
 
@@ -438,7 +438,7 @@ mod tests {
     }
 
     #[test]
-    fn test_annoucement_cache_insert_ignore_older() {
+    fn test_announcement_cache_insert_ignore_older() {
         let mut cache = AnnouncementCache::new(100, 3600);
         let now = timestamp_now();
 
@@ -461,7 +461,7 @@ mod tests {
     }
 
     #[test]
-    fn test_annoucement_cache_insert_overwrite() {
+    fn test_announcement_cache_insert_overwrite() {
         let mut cache = AnnouncementCache::new(100, 3600);
         let now = timestamp_now();
 
@@ -479,7 +479,7 @@ mod tests {
     }
 
     #[test]
-    fn test_annoucement_cache_insert_cap_exceeded() {
+    fn test_announcement_cache_insert_cap_exceeded() {
         let mut cache = AnnouncementCache::new(3, 3600);
         let now = timestamp_now();
 
@@ -499,7 +499,7 @@ mod tests {
     }
 
     #[test]
-    fn test_annoucement_cache_random() {
+    fn test_announcement_cache_random() {
         let mut cache = AnnouncementCache::new(100, 3600);
         let now = timestamp_now();
 
@@ -515,7 +515,7 @@ mod tests {
     }
 
     #[test]
-    fn test_annoucement_cache_all() {
+    fn test_announcement_cache_all() {
         let mut cache = AnnouncementCache::new(100, 3600);
         let now = timestamp_now();
 


### PR DESCRIPTION
Сorrected multiple spelling errors in function names where "annoucement" was mistakenly used instead of "announcement." These changes improve code clarity, maintainability, and consistency in function naming.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/0glabs/0g-storage-node/351)
<!-- Reviewable:end -->
