### PR TITLE
chore: fix issue with handling multiple files in `find` output  

### DIFF
--- a/scripts/search_abi.sh
+++ b/scripts/search_abi.sh
@@ -3,13 +3,19 @@
 directory="$1"      # The directory to search in
 filename="$2"       # The filename to search for
 
-# Find the file in the directory
-found_files=$(find "$directory" -type f -name "$filename")
+# Ensure both arguments are provided
+if [ -z "$directory" ] || [ -z "$filename" ]; then
+    echo "Usage: $0 <directory> <filename>" >&2
+    exit 1
+fi
+
+# Find the file and store results in an array
+mapfile -t found_files < <(find "$directory" -type f -name "$filename")
 
 # Check if any files were found
-if [ -z "$found_files" ]; then
+if [ "${#found_files[@]}" -eq 0 ]; then
     echo "Error: No files named '$filename' found in directory '$directory'." >&2
-    exit 1 
+    exit 1
 else
-    echo "$found_files"
+    printf "%s\n" "${found_files[@]}"
 fi


### PR DESCRIPTION
I fixed an issue where `find` would return multiple files with line breaks, causing the check `if [ -z "$found_files" ]` to fail. 

Now, the results are stored in an array using `mapfile`, and we check the array length to handle the files correctly, even if there are multiple.