### PR TITLE
Fix `is_outbound_only` Condition in `PeerInfo`

### DIFF
--- a/node/network/src/peer_manager/peerdb/peer_info.rs
+++ b/node/network/src/peer_manager/peerdb/peer_info.rs
@@ -182,7 +182,7 @@ impl PeerInfo {
 
     /// Checks if the peer is outbound-only
     pub fn is_outbound_only(&self) -> bool {
-        matches!(self.connection_status, Connected {n_in, n_out} if n_in == 0 && n_out > 0)
+        matches!(self.connection_status, Connected { n_in: 0, n_out: n @ 1.. })
     }
 
     /// Returns the number of connections with this peer.


### PR DESCRIPTION
This PR updates the `is_outbound_only` function in `PeerInfo` to use a clearer pattern matching syntax. The previous implementation used an inline conditional check, while the new version explicitly binds `n_out` to a range, improving readability.

## Changes
- Updated `is_outbound_only` to use `matches!(self.connection_status, Connected { n_in: 0, n_out: n @ 1.. })` instead of `if n_in == 0 && n_out > 0`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/0glabs/0g-storage-node/355)
<!-- Reviewable:end -->
