### PR TITLE
chore: improve file search handling in bash script

### DIFF
--- a/scripts/search_abi.sh
+++ b/scripts/search_abi.sh
@@ -4,12 +4,12 @@ directory="$1"      # The directory to search in
 filename="$2"       # The filename to search for
 
 # Find the file in the directory
-found_files=$(find "$directory" -type f -name "$filename")
+mapfile -t found_files < <(find "$directory" -type f -name "$filename")
 
 # Check if any files were found
-if [ -z "$found_files" ]; then
+if [ ${#found_files[@]} -eq 0 ]; then
     echo "Error: No files named '$filename' found in directory '$directory'." >&2
     exit 1 
 else
-    echo "$found_files"
+    printf "%s\n" "${found_files[@]}"
 fi


### PR DESCRIPTION
I noticed that the original script could run into issues when filenames contained spaces or special characters. Additionally, checking for an empty result using `[ -z "$found_files" ]` could lead to unexpected behavior when multiple files were found.  

I've updated the script to use `mapfile`, which ensures proper handling of filenames and provides a more reliable check for empty results.

Now, filenames with spaces and special characters are processed correctly.