### PR TITLE
improve error message in Proof::new to include actual lengths

### DIFF
--- a/common/append_merkle/src/proof.rs
+++ b/common/append_merkle/src/proof.rs
@@ -13,7 +13,7 @@ impl<T: HashElement> Proof<T> {
     /// Creates new MT inclusion proof
     pub fn new(hash: Vec<T>, path: Vec<bool>) -> Result<Proof<T>> {
         if hash.len() != path.len() + 2 {
-            bail!("hash and path length mismatch");
+            bail!("Proof::new: expected hash length = path.len() + 2, but got {} and {}", hash.len(), path.len());
         }
         Ok(Proof { lemma: hash, path })
     }


### PR DESCRIPTION

### Description:

I encountered an error in the last debugging session while initializing a new `Proof` using the `Proof::new` method. The error message simply was:

```rust
bail!("hash and path length mismatch");
```

This message did not include enough context to easily determine the problem. The error didn't state what lengths were being passed.

To improve this, I rewrote the error message to be more helpful. Now, if there is a mismatch, the error message will also indicate the actual lengths of the hash and the path. The new message is:

```rust
bail!("Proof::new: expected hash length = path.len() + 2, but got {} and {}", hash.len(), path.len());
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/0glabs/0g-storage-node/362)
<!-- Reviewable:end -->
