### PR TITLE
ci: bump actions/checkout to v4

### DIFF
--- a/.github/workflows/abi.yml
+++ b/.github/workflows/abi.yml
@@ -12,14 +12,14 @@ jobs:
 
     steps:
     - name: Clone current repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Get the Git revision from the current repository
       id: get-rev
       run: echo "rev=$(cat ./storage-contracts-abis/0g-storage-contracts-rev)" >> $GITHUB_OUTPUT
 
     - name: Clone another repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         repository: '0glabs/0g-storage-contracts'
         path: '0g-storage-contracts'

--- a/.github/workflows/cc.yml
+++ b/.github/workflows/cc.yml
@@ -29,7 +29,7 @@ jobs:
         swap-storage: true
 
     - name: Checkout sources
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         submodules: recursive
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: recursive
       - name: Setup Rust (cache & toolchain)
@@ -37,7 +37,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: recursive
       - name: Setup Rust (cache & toolchain)
@@ -53,7 +53,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: recursive
       - name: Setup Rust (cache & toolchain)

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,7 +29,7 @@ jobs:
         swap-storage: true
         
     - name: Checkout sources
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         submodules: recursive
 


### PR DESCRIPTION
Hey ! GitHub‑hosted runners now use Node 20, so checkout v4 is required
This PR updates all workflows to actions/checkout@v4 , no functional changes expected

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/0glabs/0g-storage-node/365)
<!-- Reviewable:end -->
