### PR TITLE
docs: fix typos

### DIFF
--- a/node/network/src/behaviour/mod.rs
+++ b/node/network/src/behaviour/mod.rs
@@ -1017,8 +1017,8 @@ impl std::convert::From<Request> for OutboundRequest {
 /// The type of RPC responses the Behaviour informs it has received, and allows for sending.
 ///
 // NOTE: This is an application-level wrapper over the lower network level responses that can be
-//       sent. The main difference is the absense of Pong and Metadata, which don't leave the
-//       Behaviour. For all protocol reponses managed by RPC see `RPCResponse` and
+//       sent. The main difference is the absence of Pong and Metadata, which don't leave the
+//       Behaviour. For all protocol responses managed by RPC see `RPCResponse` and
 //       `RPCCodedResponse`.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Response {

--- a/node/router/src/service.rs
+++ b/node/router/src/service.rs
@@ -299,7 +299,7 @@ impl RouterService {
             }
             NetworkMessage::Publish { messages } => {
                 if self.libp2p.swarm.connected_peers().next().is_none() {
-                    // this is a boardcast message, when current node doesn't have any peers connected, try to connect any peer in config
+                    // this is a broadcast message, when current node doesn't have any peers connected, try to connect any peer in config
                     for multiaddr in &self.config.libp2p_nodes {
                         match Swarm::dial(&mut self.libp2p.swarm, multiaddr.clone()) {
                             Ok(()) => {


### PR DESCRIPTION
### Description

This PR corrects several minor typos in comments and documentation across the codebase. The changes are non-functional and purely textual to improve clarity and maintain a clean, professional codebase.

### Details

- Corrected misspellings:
  - `absense` → `absence`
  - `reponses` → `responses`
  - `boardcast` → `broadcast`

These fixes help enhance readability and eliminate minor distractions during development and code reviews.

### Additional Info

No logic or functionality has been modified. All changes are restricted to comments or non-executable doc annotations.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/0glabs/0g-storage-node/386)
<!-- Reviewable:end -->
