### PR TITLE
Fix documentation inconsistencies in directory structure

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -16,7 +16,7 @@ The [0G Storage repo](https://github.com/0glabs/0g-storage-node) is organized wi
 |   ├── : task_executor
 |   ├── : zgs_version
 |   ├── : append_merkle
-|   └── : unused port
+|   └── : unused_port
 ┌── : node
 |   ├── : chunk_pool
 |   ├── : file_location_cache
@@ -27,7 +27,7 @@ The [0G Storage repo](https://github.com/0glabs/0g-storage-node) is organized wi
 |   ├── : rpc
 |   ├── : shared_types
 |   ├── : storage
-|   ├── : storage async
+|   ├── : storage-async
 |   └── : sync
 ├── : tests
 ```


### PR DESCRIPTION
Changes Made
Fixed directory name inconsistencies in `docs/README.md`:

- Changed unused port to `unused_port `to match the actual directory name
- Changed storage async to `storage-async` to match the actual directory name

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/0glabs/0g-storage-node/389)
<!-- Reviewable:end -->
