### PR TITLE
Fix typos in Discv5 documentation comments

### DIFF
--- a/version-meld/discv5/examples/custom_executor.rs
+++ b/version-meld/discv5/examples/custom_executor.rs
@@ -1,6 +1,6 @@
 //! Demonstrates how to run a basic Discovery v5 Service with a custom tokio executor.
 //!
-//! Discv5 requires a Tokio executor with all features. A custom exuector can be passed via the
+//! Discv5 requires a Tokio executor with all features. A custom executor can be passed via the
 //! configuration parameters. If none is passed, it will use the current runtime that build the
 //! `Discv5` struct.
 //!

--- a/version-meld/discv5/src/handler/mod.rs
+++ b/version-meld/discv5/src/handler/mod.rs
@@ -1,7 +1,7 @@
 //! Session and packet handling for the Discv5 Discovery service.
 //!
 //! The [`Handler`] is responsible for establishing and maintaining sessions with
-//! connected/discovered nodes. Each node, identified by it's [`NodeId`] is associated with a
+//! connected/discovered nodes. Each node, identified by its [`NodeId`] is associated with a
 //! `Session`. This service drives the handshakes for establishing the sessions and associated
 //! logic for sending/requesting initial connections/ENR's to/from unknown peers.
 //!
@@ -102,7 +102,7 @@ pub enum HandlerResponse {
     /// A session has been established with a node.
     ///
     /// A session is only considered established once we have received a signed ENR from the
-    /// node and received messages from it's `SocketAddr` matching it's ENR fields.
+    /// node and received messages from its `SocketAddr` matching its ENR fields.
     Established(Enr, ConnectionDirection),
 
     /// A Request has been received.


### PR DESCRIPTION
exuector → executor in examples/custom_executor.rs

it's → its where referring to possession, in src/handler/mod.rs