### PR TITLE
Update GitHub Actions setup-node to v5

### DIFF
--- a/.github/workflows/abi.yml
+++ b/.github/workflows/abi.yml
@@ -31,7 +31,7 @@ jobs:
         git checkout ${{ steps.get-rev.outputs.rev }}
 
     - name: Set up Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v5
       with:
         node-version: '18.17'
         cache: 'yarn'


### PR DESCRIPTION
Bumped actions/setup-node from v4 → v5
Using the latest version ensures continued support, bug fixes, and compatibility improvements.

Official release: https://github.com/actions/setup-node/releases/tag/v5.0.0

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/0glabs/0g-storage-node/392)
<!-- Reviewable:end -->
