### PR TITLE
chore: fix typos

### DIFF
--- a/node/storage/src/log_store/load_chunk/serde.rs
+++ b/node/storage/src/log_store/load_chunk/serde.rs
@@ -45,7 +45,7 @@ impl Decode for EntryBatchData {
                 IncompleteData::from_ssz_bytes(&bytes[1..])?,
             )),
             unknown => Err(DecodeError::BytesInvalid(format!(
-                "Unrecognized EntryBatchData indentifier {}",
+                "Unrecognized EntryBatchData identifier {}",
                 unknown
             ))),
         }

--- a/run/config-testnet-standard.toml
+++ b/run/config-testnet-standard.toml
@@ -101,7 +101,7 @@ log_sync_start_block_number = 595059
 # The number of retries after a RPC request times out.
 # rate_limit_retries = 100
 
-# The nubmer of retries for rate limited responses.
+# The number of retries for rate limited responses.
 # timeout_retries = 100
 
 # The duration to wait before retry, in ms.

--- a/run/config-testnet-turbo.toml
+++ b/run/config-testnet-turbo.toml
@@ -101,7 +101,7 @@ log_sync_start_block_number = 1
 # The number of retries after a RPC request times out.
 # rate_limit_retries = 100
 
-# The nubmer of retries for rate limited responses.
+# The number of retries for rate limited responses.
 # timeout_retries = 100
 
 # The duration to wait before retry, in ms.

--- a/run/config.toml
+++ b/run/config.toml
@@ -101,7 +101,7 @@
 # The number of retries after a RPC request times out.
 # rate_limit_retries = 100
 
-# The nubmer of retries for rate limited responses.
+# The number of retries for rate limited responses.
 # timeout_retries = 100
 
 # The duration to wait before retry, in ms.


### PR DESCRIPTION
### Description

This PR corrects several minor typos in comments and documentation across the codebase. The changes are non-functional and purely textual to improve clarity and maintain a clean, professional codebase.

### Details

- Corrected misspellings:
  - `indentifier` → `identifier`
  - `nubmer` → `number`

These fixes help enhance readability and eliminate minor distractions during development and code reviews.

### Additional Info

No logic or functionality has been modified. All changes are restricted to comments or non-executable doc annotations.